### PR TITLE
style: move input number to left beside currency symbol

### DIFF
--- a/src/components/molecules/DonationInput.tsx
+++ b/src/components/molecules/DonationInput.tsx
@@ -20,7 +20,6 @@ import { SatoshiIcon } from '../icons';
 const useStyles = createUseStyles({
 	inputElement: {
 		borderWidth: '2px',
-		textAlign: 'center',
 		'&:focus': {
 			borderColor: colors.normalLightGreen,
 			boxShadow: `0 0 0 1px ${colors.normalLightGreen}`,


### PR DESCRIPTION
Notion: https://www.notion.so/geyser/9129a33cc7f0479e9f171fa1ef80819c?v=bc494f2b15914e908edee79214784b38&p=dd62de50cd3b4e659ecc4e2e0b43f3bc

Just moved the donation amount input number to the left to be beside the currency symbol.

![image](https://user-images.githubusercontent.com/85003930/169428911-b332a1ae-b438-4930-a761-067cae723d92.png)
