### PR TITLE
fix: if a project has too many rewards you cannot fund the project

### DIFF
--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -12,6 +12,7 @@ const useStyles = createUseStyles({
 	cardContainer: {
 		borderRadius: '4px',
 		boxShadow: '0px 3px 12px rgba(0, 0, 0, 0.1)',
+		overflow: 'auto',
 	},
 });
 
@@ -27,4 +28,3 @@ export const Card = ({className, children, ...rest}: ICard) => {
 		</Box>
 	);
 };
-


### PR DESCRIPTION
Notion: https://www.notion.so/geyser/Big-bug-7177c5d174e44576bbf63311326471af

Pretty big UI bug where if a project has many rewards the container does not overflow to allow for scrolling and therefore you cannot fund the project.