### PR TITLE
fix: show badge tooltip on bottom to prevent first funder badge cutoff

### DIFF
--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -11,7 +11,7 @@ export const Badge = ({ badge }: { badge: string }) => {
 		}} onMouseLeave={() => setHover(false)}>
 			{hover
 && <>
-	<Box position="absolute" top="-85px" left="-93px" p={2} zIndex={2} bg="#5B5B5B" rounded="lg">
+	<Box position="absolute" bottom="-85px" left="-93px" p={2} zIndex={2} bg="#5B5B5B" rounded="lg">
 		<Text color="white" fontWeight="bold" fontSize="10px">Emoji badges</Text>
 		<HStack mt={1}>
 			<VStack spacing={0} rounded="lg" bg="rgba(0, 0, 0, 0.11)" px={3}>
@@ -40,7 +40,7 @@ export const Badge = ({ badge }: { badge: string }) => {
 			</VStack>
 		</HStack>
 	</Box>
-	<Box position="absolute" top="-24px" left="-5px" zIndex={1} borderLeft="20px solid transparent" borderRight="20px solid transparent" borderTop="20px solid #5B5B5B"/>
+	<Box position="absolute" bottom="-24px" left="-5px" zIndex={1} borderLeft="20px solid transparent" borderRight="20px solid transparent" borderBottom="20px solid #5B5B5B"/>
 </>
 			}
 			<Text fontSize="10px">{badge}</Text>


### PR DESCRIPTION
Currently the first funders badges tooltip will get cutoff due to a UI bug, this is likely the most important one because the first funder on the leaderboard is likely to have badges, and that will be the first interaction the user has. Me and @MickMorucci discussed just moving the tooltip to the bottom, this won't prevent the last person on the leaderboard from having their badge tooltip cutoff, but it should cause less issues. We may rethink how we show this badge information in the future. There also might be a React library that solves for this.

![image](https://user-images.githubusercontent.com/85003930/170534817-67ad4ade-4d45-4b64-8992-5e2fb66063dd.png)


