### PR TITLE
feat: ellipse username if too long with or without badges to fit 7 digit

### DIFF
--- a/src/components/ui/LinkableAvatar.tsx
+++ b/src/components/ui/LinkableAvatar.tsx
@@ -9,16 +9,29 @@ interface ILinkableAvatar {
 }
 
 export const LinkableAvatar = ({ avatarMetadata, badges }: ILinkableAvatar) => {
-	let badgesLength = 0;
 	const calculateBadgesLength = () => {
-		if (badges) {
-			badges.forEach(element => {
-				badgesLength = element.props.badge.length + badgesLength;
-			});
+		if (!badges) {
+			return 0;
 		}
+
+		return badges.reduce((length, element) => length + element.props.badge.length, 0);
 	};
 
-	calculateBadgesLength();
+	const getFormattedUsername = () => {
+		if (!avatarMetadata.username) {
+			return;
+		}
+
+		if (!badges && avatarMetadata.username.length > 25) {
+			return `${avatarMetadata.username.slice(0, 23)}...`;
+		}
+
+		if (badges && badges.length && avatarMetadata.username.length + calculateBadgesLength() > 22) {
+			return `${avatarMetadata.username.slice(0, 4)}...`;
+		}
+
+		return avatarMetadata.username;
+	};
 
 	return (
 		<Link
@@ -41,15 +54,7 @@ export const LinkableAvatar = ({ avatarMetadata, badges }: ILinkableAvatar) => {
 				/>
 				<Text fontSize="16px">
 					{' '}
-					{badges && badges.length && avatarMetadata && avatarMetadata.username
-						? avatarMetadata.username.length + badgesLength > 22
-							? `${avatarMetadata.username.slice(0, 4)}...`
-							: avatarMetadata.username
-						: avatarMetadata
-              && avatarMetadata.username
-              && avatarMetadata.username.length > 25
-							? `${avatarMetadata.username.slice(0, 23)}...`
-							: avatarMetadata.username}
+					{getFormattedUsername()}
 				</Text>
 				{badges}
 			</HStack>


### PR DESCRIPTION
Notion: https://www.notion.so/geyser/9129a33cc7f0479e9f171fa1ef80819c?v=bc494f2b15914e908edee79214784b38&p=cd5d6c28cc93470db7f16407e618140c

As discussed on Discord, this feature will ellipse the username if it is too long on it's own or with badges to fit a 7 digit donation amount and not break the UI of the component.

![image](https://user-images.githubusercontent.com/85003930/170571220-24ee23b9-fd9d-44c2-83b4-f69aa78b7187.png)
![image](https://user-images.githubusercontent.com/85003930/170571252-59015c2b-607d-42fd-b49a-57167d36f243.png)
![image](https://user-images.githubusercontent.com/85003930/170571312-ae874708-ea6f-4770-90e3-b97e1988d1b9.png)
