### PR TITLE
fix: bug if the rewards desc was not long enough it would not fill cont

### DIFF
--- a/src/pages/project/Activity/PaymentPage.tsx
+++ b/src/pages/project/Activity/PaymentPage.tsx
@@ -92,7 +92,7 @@ export const PaymentPage = ({
 
 			case projectTypes.reward:
 				return (
-					<Box>
+					<Box width="100%">
 						<RewardBased {...{rewards, setState, updateReward}}/>
 						<Divider borderTopWidth="3px" borderBottomWidth="0px" orientation="horizontal" marginTop="0px !important" />
 					</Box>


### PR DESCRIPTION
There is no Notion for this bug, but it was reported in Discord. For the Anatomy of Bitcoin project, the rewards section did not fill the width of the container. This is because there is a short description for each reward item and it's container was not set to fill the full width. So only projects with longer description would fill the container width.

Before:
![image](https://user-images.githubusercontent.com/85003930/171524161-2085031e-ceb4-4021-a9c8-13828dba8084.png)

After:
![image](https://user-images.githubusercontent.com/85003930/171524193-9f8fab47-3445-430e-ba1a-3886da3f71cb.png)
