### PR TITLE
fix: qr code was hidden on very small mobile devices

### DIFF
--- a/src/pages/project/Activity/QrPage.tsx
+++ b/src/pages/project/Activity/QrPage.tsx
@@ -171,9 +171,9 @@ export const QrPage = ({
 				</VStack>
 
 			</Card>
-			<Card width="100%" borderRadius="5px">
+			<Card width="100%" borderRadius="5px" overflow="auto">
 				<Tabs variant="enclosed" isFitted onChange={setPlatform}>
-					<TabList >
+					<TabList>
 						<Tab className={platform === 0 ? classes.tabActive : ''} value="lightning" ><BsLightning/><Text marginLeft="3px">Lightning</Text></Tab>
 						{hasOnChain(name) && <Tab className={platform === 1 ? classes.tabActive : ''} value="onChain" ><GiCrossedChains /><Text marginLeft="3px">On-chain</Text></Tab>}
 					</TabList>


### PR DESCRIPTION
Notion: https://www.notion.so/geyser/9129a33cc7f0479e9f171fa1ef80819c?v=bc494f2b15914e908edee79214784b38&p=f8532974c9234ca094e0a7053d90e4e4

The QR code for an invoice was hidden on very small mobile devices, so I made that container scrollable in this scenario. 