### PR TITLE
fix: linter warnings for not used variables

### DIFF
--- a/src/helpers/computeBadges.ts
+++ b/src/helpers/computeBadges.ts
@@ -1,5 +1,5 @@
 import { DateTime, Interval } from 'luxon';
-import { IProject, IFunder, IBadge } from '../interfaces';
+import { IBadge } from '../interfaces';
 
 interface IBadges {
     [threshold: string]: IBadge


### PR DESCRIPTION
I noticed some linter warnings during compile so I fixed them, they were just defined variables that were never used.