### PR TITLE
refactor: add more breakpoints to ellipse or remove username for badges

### DIFF
--- a/src/components/ui/LinkableAvatar.tsx
+++ b/src/components/ui/LinkableAvatar.tsx
@@ -3,6 +3,7 @@ import { Text, HStack, Box } from '@chakra-ui/layout';
 import { Avatar } from '@chakra-ui/react';
 import { IAvatarMetadata } from '../../interfaces';
 import { Link } from 'react-router-dom';
+import { isMediumScreen, isMobileMode } from '../../utils';
 
 interface ILinkableAvatar {
   avatarMetadata: IAvatarMetadata;
@@ -10,6 +11,9 @@ interface ILinkableAvatar {
 }
 
 export const LinkableAvatar = ({ avatarMetadata, badges }: ILinkableAvatar) => {
+	const isMedium = isMediumScreen();
+	const isMobile = isMobileMode();
+
 	const calculateBadgesLength = () => {
 		if (!badges) {
 			return 0;
@@ -23,12 +27,16 @@ export const LinkableAvatar = ({ avatarMetadata, badges }: ILinkableAvatar) => {
 			return;
 		}
 
-		if (!badges && avatarMetadata.username.length > 25) {
-			return `${avatarMetadata.username.slice(0, 23)}...`;
+		if ((badges && badges.length === 0 && avatarMetadata.username.length > (isMedium ? 12 : 21)) || (!badges && avatarMetadata.username.length > (isMedium ? 12 : 21))) {
+			return `${avatarMetadata.username.slice(0, (isMedium ? 10 : 19))}...`;
 		}
 
-		if (badges && badges.length && avatarMetadata.username.length + calculateBadgesLength() > 22) {
-			return `${avatarMetadata.username.slice(0, 4)}...`;
+		if (badges && badges.length >= (isMobile ? 2 : isMedium ? 1 : 3)) {
+			return;
+		}
+
+		if (badges && badges.length && avatarMetadata.username.length + calculateBadgesLength() > (isMedium ? 13 : 21)) {
+			return `${avatarMetadata.username.slice(0, (isMedium ? 3 : 6))}...`;
 		}
 
 		return avatarMetadata.username;


### PR DESCRIPTION
Notion: https://www.notion.so/geyser/9129a33cc7f0479e9f171fa1ef80819c?v=bc494f2b15914e908edee79214784b38&p=2dd577343c894ce19379aa0fa6c28885

This will add more breakpoints to either ellipse or remove the username in order to fit badges without breaking the UI. NOTE there are still some screen sizes that will break the UI, like having all 3 possible badges and a 10M+ sat donation. We will want to think of a re-design on how we display badges in the future so that the UI will not break on any screen size.

One idea I had was to show the badges when you hover on the avatar as a tooltip and then have an info tooltip near the Leaderboard tab to explain the badges.