### PR TITLE
refactor: remove ambassador badges

### DIFF
--- a/src/components/molecules/projectDisplay/ContributionProjectCard.tsx
+++ b/src/components/molecules/projectDisplay/ContributionProjectCard.tsx
@@ -112,20 +112,13 @@ export const ContributionProjectCard = ({ contribution, open, className, ...rest
 // }
 
 const RenderBadges = ({contribution}: { contribution: IContribution }) => {
-	const { project, funder, isAmbassador, isSponsor, isFunder } = contribution;
+	const { project, funder, isSponsor, isFunder } = contribution;
 	const badges = (isFunder && funder) ? computeFunderBadges({ project, funder, shortForm: false }) : [];
 
 	if (badges.length === 0) {
 		badges.push({
 			badge: 'Funder',
 			description: 'The user funded this project!',
-		});
-	}
-
-	if (isAmbassador) {
-		badges.push({
-			badge: 'Ambassador',
-			description: 'The user endorses this project!',
 		});
 	}
 


### PR DESCRIPTION
Notion: https://www.notion.so/geyser/9129a33cc7f0479e9f171fa1ef80819c?v=bc494f2b15914e908edee79214784b38&p=a740560bca7148b7a031cccefee69a87

NOTE: There is still `isAmbassador` variables in the user query and user type, this PR only removes the badges from the front-end. I didn't want to remove these other fields yet because I am not sure if it is in the scope of this request and also if you guys wanted this to be done.

I know @MickMorucci said we are going to repurpose the ambassadors table to handle the 'Approvers' for the new like functionality. So please @steliosrammos let me know if you want me to refactor this further! Thanks