### PR TITLE
update: temporarily hide grants banner until next round

### DIFF
--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -135,12 +135,12 @@ export const Home = () => {
 				flexDirection="column"
 				alignItems="flex-start"
 			>
-				{banner
+				{/* banner
 					&& <Box position="relative" marginTop={isMobile ? '15px' : '30px'}>
 						<CloseIcon position="absolute" top="15px" right="15px" cursor="pointer" color="black" onClick={() => hideBannerCached()} />
 						<Image src={GrantsBanner} alt="geyser grants" borderRadius="sm" cursor="pointer" onClick={() => history.push('/grants')} />
 					</Box>
-				}
+				*/}
 				<Box
 					display="flex"
 					flexDirection={isMobile ? 'column-reverse' : 'row'}


### PR DESCRIPTION
Notion: https://www.notion.so/geyser/9129a33cc7f0479e9f171fa1ef80819c?v=bc494f2b15914e908edee79214784b38&p=2eb09706309e49b58f3fa0f8a89014cf&pm=s

I just commented this out because we will want to enable the banner again when ROUND 2 goes live.