### PR TITLE
feat: add static selector for alby to work with lightning address

### DIFF
--- a/src/pages/project/ProjectComponent/OwnerSponsorCard.tsx
+++ b/src/pages/project/ProjectComponent/OwnerSponsorCard.tsx
@@ -85,7 +85,7 @@ export const OwnerSponsorCard = ({ project, projectDetails }: IOwnerSponsorCard)
 					<Text fontSize="md" mr={2} py="8px">{getFormattedDate(date)}</Text>
 
 					<Tooltip label={copy ? 'Copied!' : 'Copy Lightning Address'} placement="top" closeOnClick={false}>
-						<Button leftIcon={<BoltIcon/>} my={isMobile ? 2 : 0} mr={2} border="1px solid #20ECC7" _hover={{backgroundColor: 'none'}} _active={{backgroundColor: 'brand.primary'}} bg="none" fontWeight="medium" onClick={handleAddressCopy} color="#2F423E">{name}@geyser.fund</Button>
+						<Button leftIcon={<BoltIcon/>} my={isMobile ? 2 : 0} mr={2} border="1px solid #20ECC7" _hover={{backgroundColor: 'none'}} _active={{backgroundColor: 'brand.primary'}} bg="none" fontWeight="medium" onClick={handleAddressCopy} color="#2F423E" id="lightning-address">{name}@geyser.fund</Button>
 					</Tooltip>
 
 					<Tooltip label="View Project QR Code" placement="top">


### PR DESCRIPTION
Add a static ID attribute to the lightning address element on the project page so that Alby can use this to enable automatic payments.