### PR TITLE
rename projects query input variables

### DIFF
--- a/src/graphql/queries/project.ts
+++ b/src/graphql/queries/project.ts
@@ -164,8 +164,8 @@ export const QUERY_GRANTS = gql`
 `;
 
 export const QUERY_PROJECTS = gql`
-  query projects($where: ProjectQueryInput) {
-    projects(where: $where) {
+  query projects($input: ProjectsGetQueryInput) {
+    projects(input: $input) {
       projects {
         id
         title

--- a/src/hooks/useProjects.tsx
+++ b/src/hooks/useProjects.tsx
@@ -29,7 +29,9 @@ export const useProjects = (options?: OptionsProps): Result => {
     loading: isLoading,
     error,
     data: projectsData,
-  } = useQuery(QUERY_PROJECTS);
+  } = useQuery(QUERY_PROJECTS, {
+    variables: {},
+  });
 
   const projects: IProject[] = projectsData?.projects.projects || [];
 


### PR DESCRIPTION
The projects query was missing the new input variable which has support for `pagination` and `orderBy`.