### PR TITLE
add yarn to format command

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,8 +64,8 @@
     "format": "prettier --write --ignore-path .gitignore \"src/**/*.+(ts|js|tsx)\"",
     "format:generated-types": "prettier --write \"src/types/generated/graphql.ts\"",
     "graph:format": "prettier --write \"src/types/generated/graphql.ts\"",
-    "graph:fetch": "run(){ rover graph fetch geyser-graph@$1 > ./schema.graphql }; run",
-    "graph:generate": "run(){ yarn graph:fetch $1 }; run && graphql-codegen --config codegen.yaml && rm schema.graphql && yarn graph:format"
+    "graph:fetch": "run(){ rover graph fetch geyser-graph@$1 > ./schema.graphql; }; run",
+    "graph:generate": "run(){ yarn graph:fetch $1 && graphql-codegen --config codegen.yaml && rm schema.graphql && yarn graph:format; }; run",
     "graph:generate:staging": "yarn graph:generate staging"
   },
   "eslintConfig": {


### PR DESCRIPTION
@CypherPoet I had to remove rover with `yarn remove @apollo/rover` and then add it back with `yarn add -D @apollo/rover`. Not sure what happened that caused it to fail. Also needed to add `yarn` before the format command. 