### PR TITLE
WebLN false positive error toast

### DIFF
--- a/src/hooks/useFundingFlow.tsx
+++ b/src/hooks/useFundingFlow.tsx
@@ -188,10 +188,10 @@ export const useFundingFlow = (options?: IFundingFlowOptions) => {
             description: 'Please use the invoice instead.',
             status: 'info',
           })
-        } else if (fundState !== fundingStages.completed) {
+        } else {
           toast({
             title: 'Oops! Something went wrong with WebLN.',
-            description: 'Please use the invoice instead.',
+            description: 'Please copy the invoice manually instead.',
             status: 'error',
           })
         }

--- a/src/utils/formatData/sha256.ts
+++ b/src/utils/formatData/sha256.ts
@@ -1,3 +1,5 @@
+import { Buffer } from 'buffer'
+
 export const sha256 = async (hex: string) => {
   // Encode as UTF-8
   // const msgBuffer = new TextEncoder().encode(message);


### PR DESCRIPTION
https://geyserteam.atlassian.net/browse/GT-1537

- import Buffer properly so webln funding doesn't throw even if succeeding
- I took the liberty to improve the error message a bit, hope you like it but of course open to revert or change again
- I also remove the last if on the error call, as that fundState would not be updated at that promise callback anyway, so I just left that as the undefined error, in case no other error is catched before, because now it shouldn't be throwing like before.