### PR TITLE
refactor: nostr authentication

### DIFF
--- a/src/hooks/useNostrBadges.tsx
+++ b/src/hooks/useNostrBadges.tsx
@@ -9,7 +9,7 @@ import { VITE_APP_GEYSER_NOSTR_PUBKEY } from '../constants'
 import { MUTATION_USER_BADGE_AWARD } from '../graphql/mutations'
 import { MutationUserBadgeAwardArgs, UserBadge } from '../types'
 import { useNotification } from '../utils'
-import { signEvent } from '../utils/nostr/nip07'
+import { signEventToBeDeprecated } from '../utils/nostr/nip07'
 
 const relayUri = 'wss://relay.damus.io'
 
@@ -138,7 +138,7 @@ export const useNostrBadges = (pubKey: string) => {
       }
 
       eventToPublish.id = getEventHash(eventToPublish)
-      eventToPublish.sig = await signEvent(eventToPublish) // this is where you sign with private key replaccing pubkey
+      eventToPublish.sig = await signEventToBeDeprecated(eventToPublish) // this is where you sign with private key replaccing pubkey
 
       const pub = relay.publish(eventToPublish) // this is where you sign with private key replaccing pubkey
 

--- a/src/hooks/useNostrExtensionLogin.tsx
+++ b/src/hooks/useNostrExtensionLogin.tsx
@@ -1,9 +1,11 @@
+import { Buffer } from 'buffer'
+import { getEventHash } from 'nostr-tools'
 import { useState } from 'react'
 
 import { AUTH_SERVICE_ENDPOINT } from '../constants'
 import { useAuthContext } from '../context'
-import { sha256, useNotification } from '../utils'
-import { getPubkey, signMessage } from '../utils/nostr/nip07'
+import { useNotification } from '../utils'
+import { getPubkey, signEvent } from '../utils/nostr/nip07'
 
 export const useNostrExtensonLogin = () => {
   const { toast } = useNotification()
@@ -20,20 +22,33 @@ export const useNostrExtensonLogin = () => {
 
       const pubkey = await getPubkey()
 
-      const getSecret = await fetch(
-        `${AUTH_SERVICE_ENDPOINT}/nostr?pubkey=${pubkey}`,
-        {
-          credentials: 'include',
-          redirect: 'follow',
-        },
-      )
+      const getAuthEvent = await fetch(`${AUTH_SERVICE_ENDPOINT}/nostr`, {
+        credentials: 'include',
+        redirect: 'follow',
+      })
 
-      const { k1 } = await getSecret.json()
-      const hashedK1 = await sha256(k1)
-      const sig = await signMessage(hashedK1)
+      const { event } = await getAuthEvent.json()
+
+      event.pubkey = pubkey
+      event.id = getEventHash(event)
+
+      // TODO: refactor the utils sign event to return entire event
+      const signedEvent = await signEvent(event)
+      const serialisedEvent = JSON.stringify(signedEvent)
+
+      const nostrAuthToken = Buffer.from(
+        encodeURIComponent(serialisedEvent).replace(
+          /%([0-9A-F]{2})/g,
+          (_, p1) => String.fromCharCode('0x' + p1),
+        ),
+      )
+        .toString('base64')
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_')
+        .replace(/=/g, '')
 
       const response = await fetch(
-        `${AUTH_SERVICE_ENDPOINT}/nostr?pubkey=${pubkey}&k1=${k1}&sig=${sig}`,
+        `${AUTH_SERVICE_ENDPOINT}/nostr?token=${nostrAuthToken}`,
         {
           credentials: 'include',
           redirect: 'follow',

--- a/src/utils/nostr/nip07.ts
+++ b/src/utils/nostr/nip07.ts
@@ -3,7 +3,7 @@ export const signMessage = async (secret: string) => {
     try {
       const sig = await window.nostr.signSchnorr(secret)
       return sig
-    } catch (error) {}
+    } catch (error) { }
   }
 
   throw new Error('No nostr extension available')
@@ -18,7 +18,8 @@ export const getPubkey = async () => {
   throw new Error('No nostr extension available')
 }
 
-export const signEvent = async (event: {
+// Deprecate in favour of signEvent
+export const signEventToBeDeprecated = async (event: {
   [x: string]: unknown
   content: string
 }) => {
@@ -26,7 +27,21 @@ export const signEvent = async (event: {
     try {
       const { sig } = await window.nostr.signEvent(event)
       return sig
-    } catch (error) {}
+    } catch (error) { }
+  }
+
+  throw new Error('No nostr extension available')
+}
+
+export const signEvent = async (event: {
+  [x: string]: unknown
+  content: string
+}) => {
+  if (window.nostr) {
+    try {
+      const signedEvent = await window.nostr.signEvent(event)
+      return signedEvent
+    } catch (error) { }
   }
 
   throw new Error('No nostr extension available')


### PR DESCRIPTION
See updated flow described in: https://github.com/geyserfund/geyser-server/pull/204

Notes: the `signEvent` method called on the nostr object takes an unsigned event and adds a `pubkey`, `sig` and `id`. Therefore there's no need to add those manually as we do in the badges. I've marked the old implementation as `signEventToBeDeprecated` so that we remember to refactor it.