### PR TITLE
refactor: use generated hooks and types for project followers

### DIFF
--- a/src/context/auth.tsx
+++ b/src/context/auth.tsx
@@ -32,7 +32,6 @@ const defaultContext: AuthContextProps = {
   },
   setUser(user: User) {},
   followedProjects: [],
-  queryFollowedProjects() {},
 }
 
 export type NavContextProps = {
@@ -58,7 +57,6 @@ type AuthContextProps = {
   getAuthToken: () => Promise<boolean>
   setUser: (user: User) => void
   followedProjects: Project[]
-  queryFollowedProjects: () => void
 }
 
 export const AuthContext = createContext<AuthContextProps>(defaultContext)
@@ -177,7 +175,6 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
         loginOnOpen,
         loginOnClose,
         followedProjects,
-        queryFollowedProjects,
         getAuthToken,
       }}
     >

--- a/src/hooks/graphqlState/useFollowProject.tsx
+++ b/src/hooks/graphqlState/useFollowProject.tsx
@@ -1,47 +1,34 @@
-import { useMutation } from '@apollo/client'
 import React from 'react'
 
 import { useAuthContext } from '../../context'
+import { QUERY_ME_PROJECT_FOLLOWS } from '../../graphql'
 import {
-  MUTATION_FOLLOW_PROJECT,
-  MUTATION_UNFOLLOW_PROJECT,
-} from '../../graphql/mutations'
-import {
-  MutationProjectFollowArgs,
-  MutationProjectUnfollowArgs,
+  useProjectFollowMutation,
+  useProjectUnfollowMutation,
 } from '../../types'
 import { toInt } from '../../utils'
 
 export const useFollowProject = (projectId: number) => {
-  const { followedProjects, queryFollowedProjects } = useAuthContext()
+  const { followedProjects } = useAuthContext()
 
-  const [followProject, { loading: followLoading }] = useMutation<
-    any,
-    MutationProjectFollowArgs
-  >(MUTATION_FOLLOW_PROJECT, {
+  const [followProject, { loading: followLoading }] = useProjectFollowMutation({
     variables: {
       input: {
         projectId: toInt(projectId),
       },
     },
-    onCompleted() {
-      queryFollowedProjects()
-    },
+    refetchQueries: [QUERY_ME_PROJECT_FOLLOWS],
   })
 
-  const [unFollowProject, { loading: unfollowLoading }] = useMutation<
-    any,
-    MutationProjectUnfollowArgs
-  >(MUTATION_UNFOLLOW_PROJECT, {
-    variables: {
-      input: {
-        projectId: toInt(projectId),
+  const [unFollowProject, { loading: unfollowLoading }] =
+    useProjectUnfollowMutation({
+      variables: {
+        input: {
+          projectId: toInt(projectId),
+        },
       },
-    },
-    onCompleted() {
-      queryFollowedProjects()
-    },
-  })
+      refetchQueries: [QUERY_ME_PROJECT_FOLLOWS],
+    })
 
   const isFollowed = Boolean(
     followedProjects.find((project) => toInt(project?.id) === toInt(projectId)),


### PR DESCRIPTION
Does NOT resolve GEY-2145

The real cause of this issue seems to be coming from backend, but I had this change while looking at it so taking advantage and migrating to the new types.