### PR TITLE
fix: new activity indicator persists across refresh

### DIFF
--- a/src/pages/entry/EntryPage.tsx
+++ b/src/pages/entry/EntryPage.tsx
@@ -59,6 +59,7 @@ export const EntryPage = () => {
 
   const [getEntry, { loading: loadingPosts, error, data: entryData }] =
     useLazyQuery(QUERY_ENTRY, {
+      fetchPolicy: 'network-only',
       onCompleted(data) {
         const { entry } = data
         if (!entry) {

--- a/src/pages/landing/components/TabBar.tsx
+++ b/src/pages/landing/components/TabBar.tsx
@@ -16,7 +16,7 @@ export const TabBar = (props: TabBarProps) => {
   const { clearFilter } = useFilterContext()
   const navigate = useNavigate()
   const { user } = useAuthContext()
-  const { activities } = useActivitySubsciptionContext()
+  const { hasNewActivity } = useActivitySubsciptionContext()
 
   const isCurrentTabActivity = useMatch(getPath('landingFeed'))
 
@@ -61,7 +61,7 @@ export const TabBar = (props: TabBarProps) => {
           alignItems="center"
         >
           <Text fontSize="16px">Activity</Text>
-          {activities.length > 0 && (
+          {hasNewActivity && (
             <Box
               height="10px"
               width="10px"

--- a/src/pages/landing/feed/ActivityFeed.tsx
+++ b/src/pages/landing/feed/ActivityFeed.tsx
@@ -103,7 +103,10 @@ export const ActivityFeed = () => {
         {!isMobile && <FilterTopBar noSort paddingBottom="20px" />}
 
         {subscriptionActivities.length > 0 && (
-          <ViewUpdates onClick={handleClick} />
+          <ViewUpdates
+            length={subscriptionActivities.length}
+            onClick={handleClick}
+          />
         )}
 
         <ActivityList activities={aggregatedActivites} />
@@ -142,11 +145,27 @@ export const ContributionsSkeleton = () => {
   )
 }
 
-export const ViewUpdates = ({ onClick }: { onClick: () => void }) => {
+const ViewUpdates = ({
+  onClick,
+  length,
+}: {
+  length: number
+  onClick: () => void
+}) => {
+  const displayText =
+    length > 1 ? `Show ${length} new items` : `Show ${length} new item`
   return (
     <>
-      <Button size="sm" variant="outlined" onClick={onClick}>
-        view updates
+      <Button
+        size="sm"
+        variant="transparent"
+        onClick={onClick}
+        _hover={{}}
+        _focus={{ color: 'primary.700' }}
+        _active={{ color: 'primary.700' }}
+        color="primary.500"
+      >
+        {displayText}
       </Button>
       <Divider borderBottomWidth="2px" maxWidth="500px" color="brand.200" />
     </>


### PR DESCRIPTION
Resolves: 
[GEY-1937/showing-notification-in-activity-when-logged-in-user-has-not-seen-them](https://linear.app/geyser/issue/GEY-1937/showing-notification-in-activity-when-logged-in-user-has-not-seen-them)