### PR TITLE
fix: add match value for youtu.be formatted links

### DIFF
--- a/src/helpers/getIconForLinks.tsx
+++ b/src/helpers/getIconForLinks.tsx
@@ -79,7 +79,10 @@ export const getIconForLink = (value: Maybe<string>) => {
     return BsInstagram
   }
 
-  if (value?.toLowerCase().includes('youtube')) {
+  if (
+    value?.toLowerCase().includes('youtube') ||
+    value?.toLowerCase().includes('youtu.be')
+  ) {
     return BsYoutube
   }
 


### PR DESCRIPTION
resolves:
https://linear.app/geyser/issue/GEY-2239/youtube-links-not-showing-with-youtube-icon