### PR TITLE
feat: project navigation icons only on smaller screens

### DIFF
--- a/src/config/theme.ts
+++ b/src/config/theme.ts
@@ -97,6 +97,17 @@ export const theme = extendTheme({
             backgroundColor: colors.primary100,
           },
         },
+        transparent: {
+          backgroundColor: 'transparent',
+          _hover: {
+            borderColor: colors.primary400,
+            backgroundColor: colors.neutral100,
+          },
+          _active: {
+            borderColor: colors.primary400,
+            backgroundColor: colors.primary100,
+          },
+        },
         danger: {
           backgroundColor: colors.secondaryRed,
           color: colors.neutral0,

--- a/src/pages/projectView/projectNavigation/components/ProjectNavigation.tsx
+++ b/src/pages/projectView/projectNavigation/components/ProjectNavigation.tsx
@@ -1,4 +1,11 @@
-import { Button, ButtonProps, VStack } from '@chakra-ui/react'
+import {
+  Button,
+  ButtonProps,
+  IconButton,
+  IconButtonProps,
+  useBreakpointValue,
+  VStack,
+} from '@chakra-ui/react'
 import { PropsWithChildren } from 'react'
 
 import { EntryEditIcon, RewardGiftIcon } from '../../../../components/icons'
@@ -23,12 +30,13 @@ export const ProjectNavigation = ({
     <VStack ml={4} pt={5} pb={2}>
       <ProjectBackButton width="100%" />
       {hasItems ? (
-        <CardLayout padding={2}>
-          <VStack maxWidth="100%">
+        <CardLayout padding={2} width="100%">
+          <VStack width="100%">
             <ProjectNavigationButton
               // isActive={inView === 'header'}
               onClick={onProjectClick}
-              leftIcon={<ProjectIcon />}
+              aria-label="header"
+              leftIcon={<ProjectIcon height="1.6em" />}
             >
               Project
             </ProjectNavigationButton>
@@ -36,6 +44,7 @@ export const ProjectNavigation = ({
               <ProjectNavigationButton
                 // isActive={inView === 'entries'}
                 onClick={onEntriesClick}
+                aria-label="entries"
                 leftIcon={<EntryEditIcon />}
               >
                 Entries
@@ -45,6 +54,7 @@ export const ProjectNavigation = ({
               <ProjectNavigationButton
                 // isActive={inView === 'rewards'}
                 onClick={onRewardsClick}
+                aria-label="rewards"
                 leftIcon={<RewardGiftIcon />}
               >
                 Rewards
@@ -54,6 +64,7 @@ export const ProjectNavigation = ({
               <ProjectNavigationButton
                 // isActive={inView === 'milestones'}
                 onClick={onMilestonesClick}
+                aria-label="milestones"
                 leftIcon={<MilestoneIcon />}
               >
                 Milestones
@@ -68,13 +79,30 @@ export const ProjectNavigation = ({
 
 export const ProjectNavigationButton = ({
   children,
+  leftIcon,
   ...props
 }: PropsWithChildren<
-  Pick<ButtonProps, 'leftIcon' | 'onClick' | 'isActive'>
+  Pick<ButtonProps, 'leftIcon' | 'onClick' | 'isActive'> &
+    Pick<IconButtonProps, 'aria-label'>
 >) => {
-  return (
-    <Button justifyContent="start" width="100%" variant="secondary" {...props}>
-      <H3 pl={1}>{children}</H3>
-    </Button>
-  )
+  const hideLabel = useBreakpointValue({ base: true, xl: false })
+
+  const Component = hideLabel ? IconButton : Button
+
+  const ComponentProps = hideLabel
+    ? {
+        variant: 'secondary',
+        children: leftIcon,
+        ...props,
+      }
+    : {
+        leftIcon,
+        width: '100%',
+        justifyContent: 'start',
+        variant: 'transparent',
+        children: <H3 pl={1}>{children}</H3>,
+        ...props,
+      }
+
+  return <Component {...ComponentProps} />
 }


### PR DESCRIPTION
Resolves [GEY-2305](https://linear.app/geyser/issue/GEY-2305/turn-icontext-into-icon-only-when-the-screen-size-is-small)

PS: INCLUDES CHANGES FROM THESE OTHER TWO PR'S

https://github.com/geyserfund/geyser-app/pull/872
https://github.com/geyserfund/geyser-app/pull/881

REVIEW WHEN THOSE ARE MERGED ONLY!