### PR TITLE
fix: remove disabled logic for translations and add spanish back

### DIFF
--- a/src/components/nav/top-nav-bar/ModeChange.tsx
+++ b/src/components/nav/top-nav-bar/ModeChange.tsx
@@ -15,7 +15,7 @@ import {
   LanguageRequestUrl,
   languages,
 } from '../../../constants'
-import { allTranslations, EnglishTranslations } from '../../../translations'
+import { allTranslations } from '../../../translations'
 import { ColorModeSwitcher } from '../../../utils'
 import { SatSymbolIcon } from '../../icons'
 import { Modal } from '../../layouts'
@@ -26,20 +26,12 @@ export const ModeChange = () => {
   const { isOpen, onClose, onOpen } = useDisclosure()
 
   const renderLanguages = Object.keys(allTranslations).map((key) => {
-    const EnglishLength = Object.keys(EnglishTranslations).length
     const translation = allTranslations[key as keyof typeof allTranslations]
-    const LanguageLength = Object.keys(translation).length
-    const languageCoveragePercentage = (LanguageLength / EnglishLength) * 100
 
     const language = {
       key,
       translation,
-      disabled: true,
-    }
-
-    if (languageCoveragePercentage >= 70) {
-      language.disabled = false
-      return language
+      disabled: false,
     }
 
     return language

--- a/src/config/i18next.ts
+++ b/src/config/i18next.ts
@@ -14,7 +14,7 @@ import {
   ItalianTranslations,
   PolishTranslations,
   PortugueseTranslation,
-  // SpanishTranslations,
+  SpanishTranslations,
 } from '../translations'
 
 i18next
@@ -54,9 +54,9 @@ i18next
       [lng.zh]: {
         translation: ChineseTranslations,
       },
-      // [lng.es]: {
-      //   translation: SpanishTranslations,
-      // },
+      [lng.es]: {
+        translation: SpanishTranslations,
+      },
       [lng.pt]: {
         translation: PortugueseTranslation,
       },


### PR DESCRIPTION
Now that spanish translations are at 69%, I'm removing the restriction for under 70%, as this would descrease as long as we keep adding data, and some translators are not keeping up to date. Having them on and off would be prevented, although some parts would be untranslated.