### PR TITLE
fix: add fallback for regex

### DIFF
--- a/src/forms/markdown/helpers/PreviewRenderer.tsx
+++ b/src/forms/markdown/helpers/PreviewRenderer.tsx
@@ -53,7 +53,7 @@ const replaceMatchingRegex = (str: string) => {
     if (!line.match(/.*(\|\n|\||>)/)) {
       return line.replace(
         /(.*)(\n)(.*(\*|_|#|-|\[|>|\n\||\||`|[0-9]+(\.|\))))/g,
-        '$1\n#1#',
+        '<br />',
       )
     }
 


### PR DESCRIPTION
resolves, the last reload issue was actually caused by this. 
We would still need this to support markdown in older safari browsers

resolves GEY-3945