### PR TITLE
fix: create/update reward state fixes when closing and reopening modal

### DIFF
--- a/src/pages/projectView/projectMainBody/components/RewardAdditionModal.tsx
+++ b/src/pages/projectView/projectMainBody/components/RewardAdditionModal.tsx
@@ -144,7 +144,7 @@ export const RewardAdditionModal = ({
 
     setFormCostDollarValue(defaultProjectReward.cost)
     return setReward(defaultProjectReward)
-  }, [props.reward])
+  }, [props.reward, isOpen])
 
   const handleTextChange = (
     event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,

--- a/src/pages/projectView/projectNavigation/components/ProjectCreatorModal.tsx
+++ b/src/pages/projectView/projectNavigation/components/ProjectCreatorModal.tsx
@@ -13,6 +13,7 @@ import { Body2, H3 } from '../../../../components/typography'
 import { getPath } from '../../../../constants'
 import { useProjectContext } from '../../../../context'
 import { UseModalReturn } from '../../../../hooks/useModal'
+import { defaultProjectReward } from '../../../../defaults'
 
 export const ProjectCreatorModal = (props: UseModalReturn) => {
   const { t } = useTranslation()
@@ -38,7 +39,7 @@ export const ProjectCreatorModal = (props: UseModalReturn) => {
           )}
           onClick={() => {
             props.onClose()
-            onRewardsModalOpen()
+            onRewardsModalOpen({reward: defaultProjectReward})
           }}
         />
         <CreationMenuItem


### PR DESCRIPTION
Hotfix - please review modal state.  This component should be refactored and simplified, but this is the simplest fix to address the issue.

Testing:
- You can open create reward, close, and edit an existing reward
- You can open an existing reward, close, and reopen and state of existing reward is preserved
- You can open an existing reward, close, and open create reward and all fields are ready for new insertion of reward.