### PR TITLE
fix: recent activity redirect to feed

### DIFF
--- a/src/navigation/topNarBarMenu/TopNavBarMenuList.tsx
+++ b/src/navigation/topNarBarMenu/TopNavBarMenuList.tsx
@@ -101,7 +101,7 @@ export const TopNavBarMenuList = ({ sideNav }: { sideNav?: boolean }) => {
           </>
         ) : null}
 
-        <MenuItemLink fontWeight={'bold'} destinationPath={getPath('index')}>
+        <MenuItemLink fontWeight={'bold'} destinationPath={getPath('landingFeed')}>
           {t('Recent Activity')}
         </MenuItemLink>
 


### PR DESCRIPTION
https://linear.app/geyser/issue/GYS-6699/clicking-on-recent-activity-should-take-me-to-activity