### PR TITLE
Fix: text entered in tag is dark mode is hard to read

### DIFF
--- a/src/components/ui/SelectComponent.tsx
+++ b/src/components/ui/SelectComponent.tsx
@@ -69,6 +69,7 @@ export function SelectComponent<T, S extends boolean>({
       }),
       input: (provided: any, state: any) => ({
         ...provided,
+        color: colors.neutral[900],
         margin: '0px',
         padding: '0px',
       }),

--- a/src/pages/projectCreate/components/ProjectRegion.tsx
+++ b/src/pages/projectCreate/components/ProjectRegion.tsx
@@ -143,6 +143,8 @@ export const ProjectRegion = ({ location, updateProject, ...rest }: ProjectRegio
             getOptionValue={(option: Country) => option.code}
             onInputChange={handleInputChange}
             inputValue={inputValue}
+            onMenuOpen={onOpen}
+            onMenuClose={onClose}
           />
         )}
         <HStack width="100%" spacing="10px">

--- a/src/pages/projectCreate/components/ProjectTagsCreateEdit.tsx
+++ b/src/pages/projectCreate/components/ProjectTagsCreateEdit.tsx
@@ -200,6 +200,8 @@ export const ProjectTagsCreateEdit = ({ tags, updateTags, ...rest }: ProjectTags
               onKeyDown={handleKeyDown}
               inputValue={inputValue}
               components={{ Menu }}
+              onMenuOpen={onOpen}
+              onMenuClose={onClose}
             />
           )}
           <HStack width="100%" spacing="10px">


### PR DESCRIPTION
https://linear.app/geyser/issue/GYS-6723/text-entered-in-tag-is-dark-mode-is-hard-to-read