### PR TITLE
fix: only display funded applicants when grant closed

### DIFF
--- a/src/pages/grants/grantsPage/GrantPage.tsx
+++ b/src/pages/grants/grantsPage/GrantPage.tsx
@@ -58,7 +58,10 @@ export const GrantPage = () => {
       ? (grant.applicants.filter((applicant) =>
           Boolean(
             applicant &&
-              (applicant.status === GrantApplicantStatus.Accepted || applicant.status === GrantApplicantStatus.Funded),
+              (grant.status === GrantStatusEnum.Closed
+                ? applicant.status === GrantApplicantStatus.Funded
+                : applicant.status === GrantApplicantStatus.Accepted ||
+                  applicant.status === GrantApplicantStatus.Funded),
           ),
         ) as Array<GrantApplicant>)
       : []


### PR DESCRIPTION
https://linear.app/geyser/issue/GYS-7125/refactor-grants-query-to-filter-applicants