### PR TITLE
Hotfix/grant-contribute-issue

### DIFF
--- a/src/modules/project/pages/projectFunding/ProjectFunding.tsx
+++ b/src/modules/project/pages/projectFunding/ProjectFunding.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 
 import { Project, UserMeFragment } from '../../../../types'
-import { FundingProvider } from '../../context/FundingProvider'
+import { FundingProvider, useFundingContext } from '../../context/FundingProvider'
 import { FundingStages, useFundingStage } from '../../funding/state'
 import { QRCodeSection } from '../projectView/views/projectActivityPanel/screens'
 import { FundingComplete } from './views/FundingComplete'
@@ -29,6 +29,7 @@ export const ProjectFundingContent = ({ project, user, onTitleChange = noop }: P
   const [formState, setFormState] = useState<ProjectFundingFormState | undefined>()
 
   const { fundingStage, setFundingStage } = useFundingStage()
+  const { resetFundingFlow } = useFundingContext()
 
   useEffect(() => {
     if (fundingStage === FundingStages.initial) {
@@ -39,6 +40,12 @@ export const ProjectFundingContent = ({ project, user, onTitleChange = noop }: P
       setTitle(SUCCESS_TITLE)
     }
   }, [fundingStage, setFundingStage])
+
+  useEffect(() => {
+    return () => {
+      resetFundingFlow()
+    }
+  }, [resetFundingFlow])
 
   if (!project) {
     return null

--- a/src/modules/project/pages/projectFunding/components/ProjectFundingModal.tsx
+++ b/src/modules/project/pages/projectFunding/components/ProjectFundingModal.tsx
@@ -16,7 +16,7 @@ export const ProjectFundingModal = ({ isOpen, onClose, props }: ProjectFundingMo
   }, [props])
 
   return (
-    <Modal isCentered isOpen={isOpen} onClose={onClose} size="sm">
+    <Modal isCentered isOpen={isOpen} onClose={onClose} size="md">
       <ModalOverlay />
       <ModalContent bg="transparent" boxShadow={0}>
         <Box borderRadius="4px" bg="neutral.0" pb={3}>

--- a/src/modules/project/pages/projectFunding/views/FundingForm.tsx
+++ b/src/modules/project/pages/projectFunding/views/FundingForm.tsx
@@ -54,7 +54,7 @@ export const FundingForm = ({ project, user, onFundingRequested = () => {} }: Pr
       return false
     }
 
-    return true;
+    return true
   }
 
   const onSubmit = () => {
@@ -120,7 +120,7 @@ export const FundingForm = ({ project, user, onFundingRequested = () => {} }: Pr
         />
       </FormControl>
       <Box mt={4}>
-        <Button bg="primary.400" onClick={onSubmit} w="full">
+        <Button variant={'primary'} onClick={onSubmit} w="full">
           {t('Confirm')}
         </Button>
       </Box>

--- a/src/pages/grants/grantsPage/sections/CommunityVoting.tsx
+++ b/src/pages/grants/grantsPage/sections/CommunityVoting.tsx
@@ -174,7 +174,7 @@ export const CommunityVoting = ({
           </CardLayout>
         )
       })}
-      <ProjectFundingModal {...modalProps} />
+      {modalProps.isOpen && <ProjectFundingModal {...modalProps} />}
     </CardLayout>
   )
 }

--- a/src/pages/grants/grantsPage/sections/CommunityVoting.tsx
+++ b/src/pages/grants/grantsPage/sections/CommunityVoting.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Image, Text } from '@chakra-ui/react'
+import { Box, Button, Text } from '@chakra-ui/react'
 import classNames from 'classnames'
 import { useTranslation } from 'react-i18next'
 import { createUseStyles } from 'react-jss'
@@ -6,6 +6,7 @@ import { Link } from 'react-router-dom'
 
 import { CardLayout } from '../../../../components/layouts'
 import { H3 } from '../../../../components/typography'
+import { ImageWithReload } from '../../../../components/ui'
 import { getPath } from '../../../../constants'
 import { ProjectFundingModal } from '../../../../modules/project/pages/projectFunding/components/ProjectFundingModal'
 import { AvatarElement } from '../../../../modules/project/pages/projectView/views/projectMainBody/components'
@@ -99,26 +100,29 @@ export const CommunityVoting = ({
       <H3 fontSize="18px">{t(title)}</H3>
       {applicants.map(({ project, funding }) => {
         const projectLink = getPath('project', project.name)
+        const currentFunders = project.funders.filter(
+          (funder) => funder && funder.confirmedAt > fundingOpenStartDate && funder.confirmedAt <= fundingOpenEndDate,
+        )
         return (
           <CardLayout p={2} key={project.id}>
             <Box display="flex">
-              {project.thumbnailImage && (
-                <Box mr={3} height={'101px'}>
+              {
+                <Box mr={3} height={{ base: '90px', lg: '144px' }}>
                   <Link
                     to={projectLink}
                     className={classNames(classes.image, isMobile ? classes.mobileImage : classes.desktopImage)}
                   >
-                    <Image
+                    <ImageWithReload
                       objectFit="cover"
                       borderRadius="7px"
                       width={isMobile ? '90px' : '144px'}
                       height={isMobile ? '90px' : '144px'}
-                      src={project.thumbnailImage}
+                      src={project.thumbnailImage || ''}
                       alt="project thumbnail"
                     />
                   </Link>
                 </Box>
-              )}
+              }
               <Box pr={2} flexGrow={1}>
                 <Link to={projectLink}>
                   <H3 fontSize="18px">{project.title}</H3>
@@ -143,32 +147,27 @@ export const CommunityVoting = ({
                 </Box>
               )}
             </Box>
-            {canVote && (
+            {canVote && currentFunders.length > 0 && (
               <Box pl={2} filter="opacity(0.4)">
-                {project.funders
-                  .filter(
-                    (funder) =>
-                      funder && funder.confirmedAt > fundingOpenStartDate && funder.confirmedAt <= fundingOpenEndDate,
-                  )
-                  .map(
-                    (funder) =>
-                      funder && (
-                        <AvatarElement
-                          key={funder.id}
-                          width="28px"
-                          height="28px"
-                          wrapperProps={{
-                            display: 'inline-block',
-                            marginLeft: '-5px',
-                            marginTop: 2,
-                          }}
-                          avatarOnly
-                          borderRadius="50%"
-                          seed={funder.id}
-                          user={funder.user}
-                        />
-                      ),
-                  )}
+                {currentFunders.map(
+                  (funder) =>
+                    funder && (
+                      <AvatarElement
+                        key={funder.id}
+                        width="28px"
+                        height="28px"
+                        wrapperProps={{
+                          display: 'inline-block',
+                          marginLeft: '-5px',
+                          marginTop: 2,
+                        }}
+                        avatarOnly
+                        borderRadius="50%"
+                        seed={funder.id}
+                        user={funder.user}
+                      />
+                    ),
+                )}
               </Box>
             )}
             {isMobile && renderButton(project)}


### PR DESCRIPTION
fix: 
The QR code is too large for the modal

If I close the QR modal and click "Vote" on another project, I will get straight to the QR code screen again. The same is true for the Success Modal too -> this is bad because people might end up voting for the wrong project

If I refresh after opening the funding modal, I cannot click "Confirm" on funding modal. It only works after a hard refresh, I repeated it mutliple times. -> this is urgent