### PR TITLE
fix: keep emoji aligned even on title error

### DIFF
--- a/src/modules/project/pages/projectView/views/projectMainBody/components/GoalModal.tsx
+++ b/src/modules/project/pages/projectView/views/projectMainBody/components/GoalModal.tsx
@@ -127,7 +127,7 @@ export const GoalModal = ({ isOpen, onClose, goal, projectId, refetch, openDelet
                         {t('Goal Title')}
                       </Text>
                     </HStack>
-                    <HStack width="100%" alignItems="center" justifyContent="flex-start">
+                    <HStack width="100%" alignItems="flex-start" justifyContent="flex-start">
                       <ControlledEmojiInput
                         control={control}
                         name="emojiUnifiedCode"


### PR DESCRIPTION
https://linear.app/geyser/issue/GYS-7990/project-goal-title-input-misaligned-when-only-emoji-is-selected