### PR TITLE
fix: update launch plan pricing to remove "per month" and adjust tick…

### DIFF
--- a/src/modules/project/pages/projectCreation/views/start/sections/LaunchPlansSection.tsx
+++ b/src/modules/project/pages/projectCreation/views/start/sections/LaunchPlansSection.tsx
@@ -75,7 +75,7 @@ export const LaunchPlansSection = () => {
       badge: t('Partnership'),
       title: t('Geyser Partnership'),
       subtitle: t('hands-on support + network amplification'),
-      price: t('starting at $1,000 per month'),
+      price: t('starting at $1,000'),
       points: [
         t('Geyser becomes your partner providing personalized launch strategy, project feedback, and marketing support'),
         t('Dedicated Strategy & Planning: ongoing alignment on goals and execution'),
@@ -123,10 +123,11 @@ export const LaunchPlansSection = () => {
                 <VStack alignItems="flex-start" spacing={2} flex={1}>
                   {plan.points.map((point, index) => {
                     const isHighlight = plan.cardVariant === 'catalyst' && index === 0
+                    const shouldShowTick = !(plan.cardVariant === 'catalyst' && index === 0)
 
                     return (
                       <Body key={point} size="sm" fontStyle={isHighlight ? 'italic' : 'normal'}>
-                        <PiCheckCircle style={{ display: 'inline', marginRight: '8px' }} />
+                        {shouldShowTick ? <PiCheckCircle style={{ display: 'inline', marginRight: '8px' }} /> : null}
                         {point}
                       </Body>
                     )

--- a/src/modules/project/pages/projectCreation/views/start/utils/startPageContent.ts
+++ b/src/modules/project/pages/projectCreation/views/start/utils/startPageContent.ts
@@ -124,7 +124,7 @@ export const getLaunchPlans = (translate: TFunction): LaunchPlanRow[] => [
   {
     title: translate('Geyser Partnership'),
     subtitle: translate('hands-on support + network amplification'),
-    price: translate('starting at $1,000 per month'),
+    price: translate('starting at $1,000'),
     points: [
       translate('Geyser becomes your partner providing personalized launch strategy, project feedback, and marketing support'),
       translate('Dedicated Strategy & Planning: ongoing alignment on goals and execution'),


### PR DESCRIPTION
… display logic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Simplified the overall pricing display for the Geyser Partnership plan option, removing the time-based qualifier from the cost information shown in launch plan selections
  * Refined how visual checkmark indicators appear in different launch plan options, providing more consistent and clearer visual presentation across the various plan types and variants

<!-- end of auto-generated comment: release notes by coderabbit.ai -->