### PR TITLE
feat: implement email sending functionality in post publish flow

### DIFF
--- a/language/translations/en.json
+++ b/language/translations/en.json
@@ -2325,5 +2325,11 @@
   "Fund a local workshop.": "Fund a local workshop.",
   "This recoverable grant is facilitated by our trusted Field Partner,": "This recoverable grant is facilitated by our trusted Field Partner,",
   "Minimum withdrawal is {{amount}} sats. You currently have funds below the minimum in your project wallet.": "Minimum withdrawal is {{amount}} sats. You currently have funds below the minimum in your project wallet.",
-  "Go to option": "Go to option"
+  "Go to option": "Go to option",
+  "Sent email to 1 user.": "Sent email to 1 user.",
+  "Sent email to {{count}} users.": "Sent email to {{count}} users.",
+  "{{rewardName}} product image": "{{rewardName}} product image",
+  "Email will be sent to {{count}} members.": "Email will be sent to {{count}} members.",
+  "Email sent": "Email sent",
+  "Email this post to users": "Email this post to users"
 }

--- a/language/translations/es.json
+++ b/language/translations/es.json
@@ -2020,5 +2020,11 @@
   "Fund a local workshop.": "Financia un taller local.",
   "This recoverable grant is facilitated by our trusted Field Partner,": "Esta subvención recuperable es facilitada por nuestro Socio de Campo de confianza,",
   "Minimum withdrawal is {{amount}} sats. You currently have funds below the minimum in your project wallet.": "El retiro mínimo es {{amount}} sats. Actualmente tienes fondos por debajo del mínimo en tu billetera de proyecto.",
-  "Go to option": "Ir a la opción"
+  "Go to option": "Ir a la opción",
+  "Sent email to 1 user.": "Correo enviado a 1 usuario.",
+  "Sent email to {{count}} users.": "Correo enviado a {{count}} usuarios.",
+  "{{rewardName}} product image": "Imagen del producto {{rewardName}}",
+  "Email will be sent to {{count}} members.": "El correo será enviado a {{count}} miembros.",
+  "Email sent": "Correo enviado",
+  "Email this post to users": "Enviar este post por correo a los usuarios"
 }

--- a/language/translations/fr.json
+++ b/language/translations/fr.json
@@ -1548,5 +1548,11 @@
   "Pilot snapshot": "Aperçu du pilote",
   "This recoverable grant is facilitated by our trusted Field Partner,": "Cette subvention récupérable est facilitée par notre Partenaire de Terrain de confiance,",
   "Minimum withdrawal is {{amount}} sats. You currently have funds below the minimum in your project wallet.": "Le retrait minimum est de {{amount}} sats. Vous avez actuellement des fonds en dessous du minimum dans votre portefeuille de projet.",
-  "Go to option": "Aller à l'option"
+  "Go to option": "Aller à l'option",
+  "Sent email to 1 user.": "Email envoyé à 1 utilisateur.",
+  "Sent email to {{count}} users.": "Email envoyé à {{count}} utilisateurs.",
+  "{{rewardName}} product image": "{{rewardName}} image du produit",
+  "Email will be sent to {{count}} members.": "Un email sera envoyé à {{count}} membres.",
+  "Email sent": "Email envoyé",
+  "Email this post to users": "Envoyer cet article par email aux utilisateurs"
 }

--- a/src/modules/project/components/PostEmailSendForm.tsx
+++ b/src/modules/project/components/PostEmailSendForm.tsx
@@ -1,0 +1,239 @@
+import { Button, Checkbox, HStack, Select, SimpleGrid, VStack } from '@chakra-ui/react'
+import { t } from 'i18next'
+import { useEffect, useMemo, useState } from 'react'
+import { PiEnvelopeSimple } from 'react-icons/pi'
+
+import { ImageWithReload } from '@/shared/components/display/ImageWithReload.tsx'
+import { Body } from '@/shared/components/typography/Body.tsx'
+import { Feedback, FeedBackVariant } from '@/shared/molecules/Feedback.tsx'
+import {
+  EmailSubscriberSegment,
+  ProjectRewardFragment,
+  usePostEmailSegmentSizeGetQuery,
+  usePostSendByEmailMutation,
+} from '@/types/index.ts'
+import { useNotification } from '@/utils/index.ts'
+
+export type PostEmailSendOptions = {
+  segment: EmailSubscriberSegment
+  projectRewardUUIDs?: string[]
+}
+
+type PostEmailSendFormProps = {
+  postId?: number
+  projectId: number
+  rewards: ProjectRewardFragment[]
+  defaultSegment?: EmailSubscriberSegment
+  showSendButton?: boolean
+  sendButtonLabel?: string
+  onEmailSendOptionsChange?: (emailSendOptions?: PostEmailSendOptions) => void
+  onEmailCountChange?: (emailCount: number) => void
+  onEmailSent?: () => void
+}
+
+/** Shared recipient picker and sender for post email delivery. */
+export const PostEmailSendForm = ({
+  postId,
+  projectId,
+  rewards,
+  defaultSegment,
+  showSendButton = false,
+  sendButtonLabel = t('Send via email'),
+  onEmailSendOptionsChange,
+  onEmailCountChange,
+  onEmailSent,
+}: PostEmailSendFormProps) => {
+  const toast = useNotification()
+
+  const [sendTo, setSendTo] = useState<EmailSubscriberSegment | ''>(defaultSegment || '')
+  const [emailCount, setEmailCount] = useState<number>(0)
+  const [selectedRewards, setSelectedRewards] = useState<ProjectRewardFragment[]>([])
+  const [hasSentEmail, setHasSentEmail] = useState(false)
+
+  const sendToOptions = [
+    { label: t('Followers (Everyone)'), value: EmailSubscriberSegment.Followers },
+    { label: t('Contributors'), value: EmailSubscriberSegment.Contributors },
+    { label: t('Product buyers'), value: EmailSubscriberSegment.RewardBuyers },
+  ]
+
+  const projectRewardUUIDs = useMemo(
+    () => (selectedRewards.length > 0 ? selectedRewards.map((reward) => reward.uuid) : undefined),
+    [selectedRewards],
+  )
+
+  const emailSendOptions = useMemo<PostEmailSendOptions | undefined>(() => {
+    if (!sendTo) {
+      return undefined
+    }
+
+    return {
+      segment: sendTo,
+      projectRewardUUIDs,
+    }
+  }, [projectRewardUUIDs, sendTo])
+
+  const [postSendByEmail, { loading: postSendByEmailLoading }] = usePostSendByEmailMutation({
+    onCompleted(data) {
+      const recipientCount = data.postSendByEmail.recipientCount || 0
+      setHasSentEmail(true)
+      toast.success({
+        title:
+          recipientCount === 1
+            ? t('Sent email to 1 user.')
+            : t('Sent email to {{count}} users.', { count: recipientCount }),
+      })
+      onEmailSent?.()
+    },
+    onError(error) {
+      toast.error({
+        title: error.message,
+      })
+    },
+  })
+
+  usePostEmailSegmentSizeGetQuery({
+    skip: !emailSendOptions,
+    variables: {
+      input: {
+        projectId,
+        emailSendOptions: emailSendOptions as PostEmailSendOptions,
+      },
+    },
+    onCompleted(data) {
+      setEmailCount(data.postEmailSegmentSizeGet)
+      onEmailCountChange?.(data.postEmailSegmentSizeGet)
+    },
+  })
+
+  useEffect(() => {
+    onEmailSendOptionsChange?.(emailSendOptions)
+  }, [emailSendOptions, onEmailSendOptionsChange])
+
+  const handleSendToChange = (value: EmailSubscriberSegment | '') => {
+    setSendTo(value)
+    setEmailCount(0)
+    onEmailCountChange?.(0)
+    if (value !== EmailSubscriberSegment.RewardBuyers) {
+      setSelectedRewards([])
+    }
+  }
+
+  const handleRewardChange = (reward: ProjectRewardFragment, isChecked: boolean) => {
+    setEmailCount(0)
+    onEmailCountChange?.(0)
+
+    if (isChecked) {
+      setSelectedRewards((current) => [reward, ...current])
+      return
+    }
+
+    setSelectedRewards((current) => current.filter((currentReward) => currentReward.id !== reward.id))
+  }
+
+  const handleSendEmail = () => {
+    if (!postId || !emailSendOptions) {
+      return
+    }
+
+    postSendByEmail({
+      variables: {
+        input: {
+          postId,
+          emailSendOptions,
+        },
+      },
+    })
+  }
+
+  return (
+    <VStack w="full" alignItems="stretch" spacing={4}>
+      <Body size="sm" regular color="neutral1.11">
+        {t(
+          'The post title, subtitle, and image will be the only things visible in the email users receive. Make sure they’re attention-grabbing to encourage them to visit your post.',
+        )}
+      </Body>
+
+      <VStack w="full" alignItems="flex-start" spacing={2}>
+        <Body size="sm" medium>
+          {t('Send to')}
+        </Body>
+        <Select
+          size="sm"
+          value={sendTo}
+          onChange={(event) => handleSendToChange(event.target.value as EmailSubscriberSegment | '')}
+          placeholder={t('Select recipients')}
+          borderRadius="8px"
+          color="neutral1.11"
+          borderColor="neutral1.6"
+          _hover={{ borderColor: 'neutral1.8' }}
+        >
+          {sendToOptions.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </Select>
+      </VStack>
+
+      {sendTo === EmailSubscriberSegment.RewardBuyers ? (
+        <VStack w="full" alignItems="stretch" spacing={2}>
+          <Body size="sm" medium>
+            {t('Products')}
+          </Body>
+          <SimpleGrid columns={{ base: 1, md: 2 }} spacing={2}>
+            {rewards.map((reward) => {
+              const isChecked = selectedRewards.some((selectedReward) => selectedReward.id === reward.id)
+
+              return (
+                <Checkbox
+                  key={reward.id}
+                  isChecked={isChecked}
+                  onChange={(event) => handleRewardChange(reward, event.target.checked)}
+                  border="1px solid"
+                  borderColor="neutral1.6"
+                  borderRadius="8px"
+                  px={2}
+                  py={2}
+                >
+                  <HStack spacing={2} minW={0}>
+                    <ImageWithReload
+                      borderRadius="8px"
+                      width="24px"
+                      minWidth="24px"
+                      height="24px"
+                      src={reward.images[0]}
+                      alt={t('{{rewardName}} product image', { rewardName: reward.name })}
+                    />
+                    <Body size="sm" isTruncated>
+                      {reward.name}
+                    </Body>
+                  </HStack>
+                </Checkbox>
+              )
+            })}
+          </SimpleGrid>
+        </VStack>
+      ) : null}
+
+      {sendTo ? (
+        <Feedback variant={FeedBackVariant.INFO} icon={<PiEnvelopeSimple size="20px" />}>
+          <Body size="sm">{t('Email will be sent to {{count}} members.', { count: emailCount })}</Body>
+        </Feedback>
+      ) : null}
+
+      {showSendButton ? (
+        <Button
+          w="full"
+          size="lg"
+          variant="solid"
+          colorScheme="primary1"
+          onClick={handleSendEmail}
+          isDisabled={!emailSendOptions || emailCount === 0 || hasSentEmail}
+          isLoading={postSendByEmailLoading}
+        >
+          {hasSentEmail ? t('Email sent') : sendButtonLabel}
+        </Button>
+      ) : null}
+    </VStack>
+  )
+}

--- a/src/modules/project/pages/projectDashboard/views/posts/components/PublishModal.tsx
+++ b/src/modules/project/pages/projectDashboard/views/posts/components/PublishModal.tsx
@@ -1,37 +1,19 @@
-import { Button, HStack, IconButton, Switch, Tooltip, VStack } from '@chakra-ui/react'
+import { Button, HStack, Switch, Tooltip, VStack } from '@chakra-ui/react'
 import { t } from 'i18next'
 import { useState } from 'react'
-import { PiEnvelopeSimple, PiX } from 'react-icons/pi'
 import { useNavigate } from 'react-router'
-import { components, MultiValue, OptionProps } from 'react-select'
 
-import { CustomSelect } from '@/components/ui/CustomSelect'
+import { PostEmailSendForm, PostEmailSendOptions } from '@/modules/project/components/PostEmailSendForm.tsx'
 import { useProjectAtom, useRewardsAtom } from '@/modules/project/hooks/useProjectAtom'
-import { ImageWithReload } from '@/shared/components/display/ImageWithReload'
 import { Modal } from '@/shared/components/layouts'
 import { CardLayout } from '@/shared/components/layouts/CardLayout'
 import { Body } from '@/shared/components/typography'
 import { getPath } from '@/shared/constants'
 import { useModal } from '@/shared/hooks'
-import { Feedback, FeedBackVariant } from '@/shared/molecules'
-import {
-  EmailSubscriberSegment,
-  PostStatus,
-  ProjectPostFragment,
-  ProjectRewardFragment,
-  usePostEmailSegmentSizeGetQuery,
-  usePostSendByEmailMutation,
-} from '@/types'
+import { PostStatus, ProjectPostFragment, usePostSendByEmailMutation } from '@/types'
 import { isActive, useNotification } from '@/utils'
 
-import { RewardItem } from '../../../../projectView/views/posts/components/RewardItem'
 import { PostPublishProps } from '../hooks/usePostForm.tsx'
-
-const sendToOptions = [
-  { label: t('Followers (Everyone)'), value: EmailSubscriberSegment.Followers },
-  { label: t('Contributors'), value: EmailSubscriberSegment.Contributors },
-  { label: t('Product buyers'), value: EmailSubscriberSegment.RewardBuyers },
-]
 
 export const PublishModal = ({
   post,
@@ -53,26 +35,24 @@ export const PublishModal = ({
 
   const [sendEmail, setSendEmail] = useState(false)
 
-  const [sendTo, setSendTo] = useState<EmailSubscriberSegment | null>(null)
+  const [emailSendOptions, setEmailSendOptions] = useState<PostEmailSendOptions | undefined>(undefined)
   const [emailCount, setEmailCount] = useState<number>(0)
-  const [selectedRewards, setSelectedRewards] = useState<ProjectRewardFragment[]>([])
 
   const [postSendByEmail, { loading: postSendByEmailLoading }] = usePostSendByEmailMutation({
     variables: {
       input: {
         postId: post.id,
-        emailSendOptions: {
-          segment: sendTo as EmailSubscriberSegment,
-          projectRewardUUIDs: selectedRewards.length > 0 ? selectedRewards.map((reward) => reward.uuid) : undefined,
-        },
+        emailSendOptions: emailSendOptions as PostEmailSendOptions,
       },
     },
     onCompleted(data) {
       publishModal.onClose()
+      const recipientCount = data.postSendByEmail.recipientCount || 0
       toast.success({
-        title: `Sent email to ${
-          data.postSendByEmail.recipientCount === 1 ? '1 user' : `${data.postSendByEmail.recipientCount} users`
-        }.`,
+        title:
+          recipientCount === 1
+            ? t('Sent email to 1 user.')
+            : t('Sent email to {{count}} users.', { count: recipientCount }),
       })
       post.sentByEmailAt = new Date().toISOString()
     },
@@ -83,157 +63,21 @@ export const PublishModal = ({
     },
   })
 
-  usePostEmailSegmentSizeGetQuery({
-    skip: !sendTo,
-    variables: {
-      input: {
-        projectId: project.id,
-        emailSendOptions: {
-          segment: sendTo as EmailSubscriberSegment,
-          projectRewardUUIDs: selectedRewards.length > 0 ? selectedRewards.map((reward) => reward.uuid) : undefined,
-        },
-      },
-    },
-    onCompleted(data) {
-      setEmailCount(data.postEmailSegmentSizeGet)
-    },
-  })
-
-  const handleInput = (e: any) => {
-    setSendTo(e.value)
-  }
-
   const handleSendEmailChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setSendEmail(e.target.checked)
     if (!e.target.checked) {
-      setSendTo(null)
+      setEmailSendOptions(undefined)
       setEmailCount(0)
-      setSelectedRewards([])
     }
   }
 
   const handlePostPublish = async () => {
     postPublish({
-      emailSendOptions: sendTo
-        ? {
-            segment: sendTo as EmailSubscriberSegment,
-            projectRewardUUIDs: selectedRewards.length > 0 ? selectedRewards.map((reward) => reward.uuid) : undefined,
-          }
-        : undefined,
+      emailSendOptions,
       onCompleted() {
         navigate(getPath('projectPostView', project.name, post?.id), { state: { justPublished: true } })
       },
     })
-  }
-
-  const handleChange = (value: MultiValue<ProjectRewardFragment>) => {
-    if (!value[0]) {
-      return
-    }
-
-    const newReward: ProjectRewardFragment = { ...value[0] }
-    if (!selectedRewards.some((reward) => reward.id === newReward.id)) {
-      setSelectedRewards((current) => [newReward, ...current])
-    } else {
-      setSelectedRewards((current) => current.filter((reward) => reward.id !== newReward.id))
-    }
-  }
-
-  const handleRewardRemove = (reward: ProjectRewardFragment) => {
-    setSelectedRewards((current) => current.filter((r) => r.id !== reward.id))
-  }
-
-  const Option = (props: OptionProps<ProjectRewardFragment, true, any>) => {
-    return (
-      <components.Option {...props}>
-        <RewardItem imageUrl={props.data.images[0]} name={props.children} />
-      </components.Option>
-    )
-  }
-
-  const sendEmailRender = () => {
-    return (
-      <>
-        <Body size="sm" regular color="neutral1.11">
-          {t(
-            'The post title, subtitle, and image will be the only things visible in the email users receive. Make sure they’re attention-grabbing to encourage them to visit your post.',
-          )}
-        </Body>
-        <VStack w="full" alignItems="flex-start">
-          <Body size={'sm'} medium>
-            {' '}
-            {t('Send to')}
-          </Body>
-          <CustomSelect
-            placeholder={t('Select recipients')}
-            options={sendToOptions}
-            onChange={handleInput}
-            width={'100%'}
-            size="sm"
-            fontSize="sm"
-          />
-        </VStack>
-
-        {sendTo === EmailSubscriberSegment.RewardBuyers && (
-          <>
-            <CustomSelect<ProjectRewardFragment, true>
-              isMulti
-              width={'100%'}
-              onChange={handleChange}
-              name="rewards"
-              placeholder={t('Select products')}
-              value={[]}
-              options={rewards}
-              getOptionLabel={(option: ProjectRewardFragment) => option.name}
-              getOptionValue={(option: ProjectRewardFragment) => option.id}
-              components={{ Option }}
-            />
-
-            <HStack w="full" flexWrap="wrap">
-              {selectedRewards.map((reward) => (
-                <HStack
-                  key={reward.id}
-                  w="auto"
-                  maxWidth="40%"
-                  alignItems={'start'}
-                  backgroundColor="neutral1.3"
-                  padding="1"
-                  borderRadius="8px"
-                >
-                  <ImageWithReload
-                    borderRadius={'8px'}
-                    width="24px"
-                    minWidth={'24px'}
-                    height="24px"
-                    src={reward.images[0]}
-                    alt={`${reward.name} reward image`}
-                  />
-                  <Body size="sm" isTruncated>
-                    {reward.name}
-                  </Body>
-                  <IconButton
-                    aria-label="clear-product-selection"
-                    icon={<PiX />}
-                    size="sm"
-                    variant="surface"
-                    colorScheme="error"
-                    onClick={() => handleRewardRemove(reward)}
-                  />
-                </HStack>
-              ))}
-            </HStack>
-          </>
-        )}
-
-        {sendTo !== null && (
-          <Feedback variant={FeedBackVariant.INFO} icon={<PiEnvelopeSimple size="20px" />}>
-            <Body size="sm">
-              {t('Email will be sent to')} <strong> {emailCount}</strong> {t('members.')}
-            </Body>
-          </Feedback>
-        )}
-      </>
-    )
   }
 
   const canSendViaEmail = !post.sentByEmailAt
@@ -309,7 +153,14 @@ export const PublishModal = ({
             <Switch size="lg" isChecked={sendEmail} onChange={handleSendEmailChange} />
           </VStack>
         </CardLayout>
-        {sendEmail ? sendEmailRender() : null}
+        {sendEmail ? (
+          <PostEmailSendForm
+            projectId={project.id}
+            rewards={rewards}
+            onEmailSendOptionsChange={setEmailSendOptions}
+            onEmailCountChange={setEmailCount}
+          />
+        ) : null}
 
         <HStack w="full">
           <Button flex={1} variant="soft" colorScheme="neutral1" onClick={publishModal.onClose}>
@@ -321,7 +172,7 @@ export const PublishModal = ({
               variant="solid"
               colorScheme="primary1"
               onClick={() => postSendByEmail()}
-              isDisabled={emailCount === 0}
+              isDisabled={!emailSendOptions || emailCount === 0}
               isLoading={postSendByEmailLoading}
             >
               {t('Send via email')}

--- a/src/modules/project/pages/projectView/views/posts/components/PublishSuccessState.tsx
+++ b/src/modules/project/pages/projectView/views/posts/components/PublishSuccessState.tsx
@@ -1,13 +1,16 @@
 import { Box, Button, HStack, VStack } from '@chakra-ui/react'
 import { t } from 'i18next'
-import { PiArrowSquareOut, PiCheck, PiCopy, PiPencilSimple } from 'react-icons/pi'
+import { useState } from 'react'
+import { PiArrowSquareOut, PiCheck, PiCopy, PiEnvelopeSimple, PiPencilSimple } from 'react-icons/pi'
 import { useNavigate } from 'react-router'
 
-import { useProjectAtom } from '@/modules/project/hooks/useProjectAtom'
+import { PostEmailSendForm } from '@/modules/project/components/PostEmailSendForm.tsx'
+import { useProjectAtom, useRewardsAtom } from '@/modules/project/hooks/useProjectAtom.ts'
 import { getProjectPostViewUrl } from '@/modules/project/tools/generateProjectJsonLD.ts'
 import { Body, H2 } from '@/shared/components/typography'
 import { getPath } from '@/shared/constants/index.ts'
 import { useCopyToClipboard } from '@/shared/utils/hooks/useCopyButton'
+import { EmailSubscriberSegment } from '@/types/index.ts'
 
 type PublishSuccessStateProps = {
   /** The published post id */
@@ -22,6 +25,9 @@ type PublishSuccessStateProps = {
 export const PublishSuccessState = ({ postId, description, onWriteAnother, onClose }: PublishSuccessStateProps) => {
   const navigate = useNavigate()
   const { project } = useProjectAtom()
+  const { rewards } = useRewardsAtom()
+
+  const [showEmailForm, setShowEmailForm] = useState(false)
 
   const postUrl = getProjectPostViewUrl(project.name, postId)
   const { onCopy, hasCopied } = useCopyToClipboard(postUrl)
@@ -84,6 +90,28 @@ export const PublishSuccessState = ({ postId, description, onWriteAnother, onClo
           </Button>
         </HStack>
       </VStack>
+
+      {showEmailForm ? (
+        <PostEmailSendForm
+          postId={postId}
+          projectId={project.id}
+          rewards={rewards}
+          defaultSegment={EmailSubscriberSegment.Followers}
+          showSendButton
+          sendButtonLabel={t('Email this post to users')}
+        />
+      ) : (
+        <Button
+          w="full"
+          size="lg"
+          variant="solid"
+          colorScheme="primary1"
+          leftIcon={<PiEnvelopeSimple />}
+          onClick={() => setShowEmailForm(true)}
+        >
+          {t('Email this post to users')}
+        </Button>
+      )}
 
       {/* Action buttons */}
       <VStack w="full" spacing={2}>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added email-sharing options for posts, letting users send a post to selected recipient groups and, when relevant, choose specific reward products.
  * Added a new post-publishing email flow with recipient counts and send confirmations.
  * Added translated interface text for email actions and reward image labels in English, Spanish, and French.

* **Bug Fixes**
  * Improved email send button behavior so it only becomes available when recipient options are properly set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->