### PR TITLE
fix: render share QR as SVG to survive image copy on DuckDuckGo (qr-code-styling)

### DIFF
--- a/language/translations/en.json
+++ b/language/translations/en.json
@@ -2331,5 +2331,6 @@
   "{{rewardName}} product image": "{{rewardName}} product image",
   "Email will be sent to {{count}} members.": "Email will be sent to {{count}} members.",
   "Email sent": "Email sent",
-  "Email this post to users": "Email this post to users"
+  "Email this post to users": "Email this post to users",
+  "QR code": "QR code"
 }

--- a/language/translations/es.json
+++ b/language/translations/es.json
@@ -2026,5 +2026,6 @@
   "{{rewardName}} product image": "Imagen del producto {{rewardName}}",
   "Email will be sent to {{count}} members.": "El correo será enviado a {{count}} miembros.",
   "Email sent": "Correo enviado",
-  "Email this post to users": "Enviar este post por correo a los usuarios"
+  "Email this post to users": "Enviar este post por correo a los usuarios",
+  "QR code": "Código QR"
 }

--- a/language/translations/fr.json
+++ b/language/translations/fr.json
@@ -1554,5 +1554,6 @@
   "{{rewardName}} product image": "{{rewardName}} image du produit",
   "Email will be sent to {{count}} members.": "Un email sera envoyé à {{count}} membres.",
   "Email sent": "Email envoyé",
-  "Email this post to users": "Envoyer cet article par email aux utilisateurs"
+  "Email this post to users": "Envoyer cet article par email aux utilisateurs",
+  "QR code": "Code QR"
 }

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "luxon": "^3.2.1",
     "nostr-tools": "^1.7.5",
     "prerender-node": "^3.8.0",
+    "qr-code-styling": "^1.9.2",
     "qr-scanner": "^1.4.2",
     "react": "^18.2.0",
     "react-confetti": "^6.1.0",

--- a/src/modules/project/pages/projectView/hooks/useCreateAndCopyImage.ts
+++ b/src/modules/project/pages/projectView/hooks/useCreateAndCopyImage.ts
@@ -10,12 +10,35 @@ export const useCreateAndCopyImage = () => {
   const [copying, setCopying] = useState(false)
 
   const getDataUrl = useCallback(async (element: any) => {
-    if (element) {
-      const dataUrl = await toPng(element)
-      return dataUrl
+    if (!element) {
+      throw new Error('Element is not defined')
     }
 
-    throw new Error('Element is not defined')
+    // Warm-up passes only need to trigger image/font decode, so render them cheaply; only the
+    // final, returned capture needs full resolution.
+    const warmupOptions = { cacheBust: true }
+    const captureOptions = { cacheBust: true, pixelRatio: 2 }
+
+    // Wait for fonts so the banner's text renders in the capture (Safari/WebKit decodes them lazily).
+    if (document?.fonts?.ready) {
+      try {
+        await document.fonts.ready
+      } catch {
+        // ignore: fall through and capture anyway
+      }
+    }
+
+    // WebKit/iOS Safari can return a blank image on the first toPng pass (remote image/fonts not yet
+    // decoded). Warm up the render path with best-effort discarded passes (a transient failure here
+    // must not abort the export), then capture.
+    try {
+      await toPng(element, warmupOptions)
+      await toPng(element, warmupOptions)
+    } catch {
+      // ignore: warm-up passes are best-effort decode triggers
+    }
+
+    return toPng(element, captureOptions)
   }, [])
 
   const getBlob = async (element: HTMLElement | null) => {

--- a/src/modules/project/pages/projectView/views/body/sections/header/shareModal/components/ProjectShareBanner.tsx
+++ b/src/modules/project/pages/projectView/views/body/sections/header/shareModal/components/ProjectShareBanner.tsx
@@ -1,6 +1,7 @@
 import { Box, HStack, Image, StackProps, VStack } from '@chakra-ui/react'
-import { forwardRef } from 'react'
-import { QRCode } from 'react-qrcode-logo'
+import { t } from 'i18next'
+import QRCodeStyling from 'qr-code-styling'
+import { forwardRef, useEffect, useRef } from 'react'
 
 import { Body } from '@/shared/components/typography'
 
@@ -75,48 +76,63 @@ export const ProjectShareQrCodeComponent = ({
   qrSize: number
   logoSize: number
 } & StackProps) => {
+  const qrContainerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const instance = new QRCodeStyling({
+      type: 'svg',
+      width: qrSize,
+      height: qrSize,
+      margin: 0,
+      data: qrCodeValue,
+      qrOptions: { errorCorrectionLevel: 'H' },
+      backgroundOptions: { color: lightModeColors.utils.pbg },
+      dotsOptions: { type: 'dots', color: lightModeColors.utils.text },
+      cornersSquareOptions: { type: 'extra-rounded', color: lightModeColors.utils.text },
+      cornersDotOptions: { color: lightModeColors.utils.text },
+    })
+
+    if (qrContainerRef.current) {
+      qrContainerRef.current.replaceChildren()
+      instance.append(qrContainerRef.current)
+    }
+  }, [qrSize, qrCodeValue])
+
   return (
     <VStack
       borderColor={'neutral.1000'}
       overflow={'hidden'}
       _hover={{ cursor: 'pointer' }}
-      position="relative"
       backgroundColor="utils.whiteContrast"
       borderRadius={8}
-      gap={0}
-      pb={1}
+      gap={1}
+      padding={2}
     >
-      <HStack
-        background="white"
-        padding="2px"
-        position={'absolute'}
-        top={`${(qrSize - (logoSize - 6) / 2) / 2}px`}
-        left={`${(qrSize - (logoSize - 6) / 2) / 2}px`}
-        borderRadius="8px"
-        width={`${LOGO_SIZE + 4}px`}
-        height={`${LOGO_SIZE + 4}px`}
-      >
-        <HStack width={`${LOGO_SIZE}px`} height={`${LOGO_SIZE}px`} borderRadius="8px" justifyContent="center">
-          <img
-            alt="Geyser logo"
-            style={{
-              maxWidth: '100%',
-              height: '100%',
-            }}
-            src={centerLogo}
-          />
+      <Box position="relative" lineHeight={0}>
+        <Box ref={qrContainerRef} role="img" aria-label={qrCodeText ?? t('QR code')} lineHeight={0} />
+        <HStack
+          background="utils.pbg"
+          padding="2px"
+          position="absolute"
+          top="50%"
+          left="50%"
+          transform="translate(-50%, -50%)"
+          borderRadius="8px"
+          width={`${logoSize + 4}px`}
+          height={`${logoSize + 4}px`}
+        >
+          <HStack width={`${logoSize}px`} height={`${logoSize}px`} borderRadius="8px" justifyContent="center">
+            <img
+              alt=""
+              style={{
+                maxWidth: '100%',
+                height: '100%',
+              }}
+              src={centerLogo}
+            />
+          </HStack>
         </HStack>
-      </HStack>
-
-      <QRCode
-        qrStyle="dots"
-        id={lightModeColors.neutral[1000]}
-        size={qrSize}
-        bgColor={lightModeColors.utils.pbg}
-        fgColor={lightModeColors.utils.text}
-        value={qrCodeValue}
-        removeQrCodeBehindLogo={true}
-      />
+      </Box>
       {qrCodeText && (
         <Body size="xs" light>
           {qrCodeText}

--- a/yarn.lock
+++ b/yarn.lock
@@ -15469,6 +15469,7 @@ __metadata:
     nostr-tools: "npm:^1.7.5"
     prerender-node: "npm:^3.8.0"
     prettier: "npm:^2.8.3"
+    qr-code-styling: "npm:^1.9.2"
     qr-scanner: "npm:^1.4.2"
     react: "npm:^18.2.0"
     react-confetti: "npm:^6.1.0"
@@ -20643,6 +20644,15 @@ __metadata:
   version: 1.5.1
   resolution: "q@npm:1.5.1"
   checksum: 10c0/7855fbdba126cb7e92ef3a16b47ba998c0786ec7fface236e3eb0135b65df36429d91a86b1fff3ab0927b4ac4ee88a2c44527c7c3b8e2a37efbec9fe34803df4
+  languageName: node
+  linkType: hard
+
+"qr-code-styling@npm:^1.9.2":
+  version: 1.9.2
+  resolution: "qr-code-styling@npm:1.9.2"
+  dependencies:
+    qrcode-generator: "npm:^1.4.4"
+  checksum: 10c0/6296e115776ec7788dacc62f2ec0e54d861cfa2a82676bcf9adc693e8bce33552bd6bd92c9ff0478d2bff8610243f7010d7bd7bf85cf96fb41d8b60a36fa56e0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
> [!IMPORTANT]
> **This is one of two alternative PRs for issue #1213. Please accept only one.**
> Both PRs fix the bug the exact same way (by rendering the QR as inline SVG). They differ **only** in the QR's visual style, and I wanted to show both options.
>
> The two options exist because the fix means replacing the canvas-based `react-qrcode-logo` (the root of the bug), and no single SVG library is a drop-in that also keeps its dotted style, so the QR's look became an open choice rather than something to decide unilaterally (see [Note on aesthetics](#note-on-aesthetics) below).
>
> - **This PR** (uses `qr-code-styling`): keeps the current **dotted** look.
> - **Alternative PR** (uses `qrcode.react`): standard **square** modules.

**Alternative PR:** #2174 (square modules, `qrcode.react`)

Fixes the project share banner so its LNURL / lightning-address QR code is present and scannable in the copied image, including on the DuckDuckGo browser (iOS and macOS).

Closes #1213

## Root cause

The banner drew its QR with `react-qrcode-logo`, which renders onto an HTML `<canvas>`. The "Copy image" flow uses `html-to-image`'s `toPng()`, which serializes any embedded `<canvas>` by calling `canvas.toDataURL()`. DuckDuckGo and other WebKit-based browsers apply canvas fingerprinting protection that poisons or blocks `toDataURL()` / `toBlob()` reads, so the QR canvas came back blank or corrupted in the output, while the rest of the banner (a plain DOM image, the logo, and the text) rendered fine. That asymmetry is the tell: the canvas QR was the one failing element.

## Fix

- Render the QR as inline **SVG** using `qr-code-styling` (type `svg`), so `html-to-image` serializes it directly with no canvas read. SVG is immune to the canvas-read protection.
- Keep the dotted module style (`dotsOptions.type: 'dots'`, rounded finder corners) to match the current look.
- Use error-correction level `H` so the code stays scannable with the center logo on top.
- Preserve the original card layout: the lightning logo stays centered over the QR and the white quiet-zone border is kept, so the banner looks the same as before apart from the rendering library. The logo is centered with a CSS transform instead of hard-coded offsets that were tuned to `react-qrcode-logo`'s (quiet-zone-padded) geometry.
- Add an accessible `aria-label` to the QR container.
- Harden `useCreateAndCopyImage` for WebKit (helps the general iOS Safari "first capture is blank" case): await `document.fonts.ready`, pass `cacheBust` / `pixelRatio`, and run a couple of cheap warm-up `toPng` passes before the final full-resolution capture.
- `react-qrcode-logo` stays in the project; it is still used by the on-screen payment QR and the auth QR, which never pass through `html-to-image` and are unaffected.

## Files changed

- `src/.../shareModal/components/ProjectShareBanner.tsx` (canvas QR to a `qr-code-styling` SVG mounted via ref; logo re-centered)
- `src/modules/project/pages/projectView/hooks/useCreateAndCopyImage.ts` (WebKit capture hardening)
- `package.json` / `yarn.lock` (add `qr-code-styling`)

## Screenshot

<img width="1280" height="920" alt="issue-1213-qr-svg-dots" src="https://github.com/user-attachments/assets/194e5180-d782-4c6a-9bd8-a6cdbf886721" />

Captured from the live component on the dev server.

The banner copies with the dotted QR present, logo centered, and quiet-zone border intact.

## Testing

- `yarn exec tsc --noEmit`: passes.
- eslint on the changed files: no new errors.
- Verified in a running dev build that the QR now renders as an inline `<svg>` built from dot `<circle>` elements (0 `<canvas>` elements), with the logo centered.

## Still to verify (needs a real device)

- DuckDuckGo on macOS and iOS: open the share banner, Copy image, paste, confirm the QR appears and scans.
- While testing, confirm the banner background image also renders in the copied output. It is a remote cross-origin image with no `crossOrigin` set, a separate latent WebKit taint risk that this PR does not touch (out of scope; flag a follow-up if it is also blank).

## Note on aesthetics

This variant preserves the current dotted look (dots with rounded finder corners), with the logo centered and the quiet-zone border kept. The trade-off versus the alternative PR is a heavier, imperative (non-React) dependency (`qr-code-styling`) mounted via a ref instead of a declarative component. If the team prefers standard square modules and a lighter dependency, accept the alternative PR instead and close this one.
