### PR TITLE
fix(sentry): ignore google logging timeouts

### DIFF
--- a/scripts/sentry-ignore-noise.mjs
+++ b/scripts/sentry-ignore-noise.mjs
@@ -155,6 +155,18 @@ const noiseGroups = [
     queries: ['"ValidationError: Email is required"'],
     patterns: ['validationerror: email is required'],
   },
+  {
+    key: 'google-logging-timeout',
+    label: 'Google Cloud Logging transport timeout noise',
+    action: 'ignored',
+    queries: [
+      '"LoggingServiceV2 exceeded 60000 milliseconds"',
+      '"google.logging.v2.LoggingServiceV2"',
+      '"Total timeout of API google.logging.v2.LoggingServiceV2"',
+    ],
+    patterns: ['google.logging.v2.loggingservicev2', 'exceeded 60000 milliseconds'],
+    requireAny: ['google-gax', 'normalcalls/retries.js', 'before any response was received'],
+  },
 ]
 
 const keepVisiblePatterns = [


### PR DESCRIPTION
### Motivation
- Reduce Sentry noise from recurring Google Cloud Logging transport timeouts reported as `Total timeout of API google.logging.v2.LoggingServiceV2 exceeded 60000 milliseconds` so actionable issues remain visible.

### Description
- Add a new noise group `google-logging-timeout` to `scripts/sentry-ignore-noise.mjs` that matches the 60s `LoggingServiceV2` timeout text and related phrases.
- Scope the rule to require `google-gax` / retry-stack context (`requireAny`) to avoid broadly ignoring unrelated timeouts.

### Testing
- Ran a local Node snippet that uses `matchesNoiseGroup` to verify the new group matches the reported `LoggingServiceV2` issue and it passed. 
- Ran `node --check scripts/sentry-ignore-noise.mjs` to validate the script syntax and it passed. 
- Attempted `npx react-doctor --verbose --diff` as requested by repository guidelines but the run was blocked by an external `npm` registry `403 Forbidden` for the `react-doctor` package.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a568306be008332942ee9692add7fa9)