### PR TITLE
Adds LABIF eligibility callout to project forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.48.0](https://github.com/geyserfund/geyser-app/compare/v0.47.1...v0.48.0) (2026-07-23)
+
+
+### Features
+
+* **project:** show LABIF eligibility callout ([4d71657](https://github.com/geyserfund/geyser-app/commit/4d7165709a4192db3eef5819a2c095720eaf642f))
+
 ## [0.47.0](https://github.com/geyserfund/geyser-app/compare/v0.46.0...v0.47.0) (2026-07-22)
 
 ## [0.46.0](https://github.com/geyserfund/geyser-app/compare/v0.45.1...v0.46.0) (2026-07-21)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "geyser-app",
   "private": true,
-  "version": "0.47.1",
+  "version": "0.48.0",
   "type": "module",
   "workspaces": [
     "packages/*"

--- a/src/modules/project/forms/ProjectForm.tsx
+++ b/src/modules/project/forms/ProjectForm.tsx
@@ -1,4 +1,5 @@
-import { Box, FormErrorIcon, HStack, Stack, VStack } from '@chakra-ui/react'
+import { gql, useLazyQuery } from '@apollo/client'
+import { Box, FormErrorIcon, HStack, Link as ChakraLink, Stack, VStack } from '@chakra-ui/react'
 import { useAtomValue } from 'jotai'
 import { ChangeEventHandler, useCallback, useEffect } from 'react'
 import { Controller, UseFormReturn } from 'react-hook-form'
@@ -17,8 +18,9 @@ import { countriesAtom } from '@/shared/state/countriesAtom.ts'
 
 import { TextArea, TextInputBox, UploadBox } from '../../../components/ui'
 import { FieldContainer } from '../../../shared/components/form/FieldContainer'
-import { ProjectValidations } from '../../../shared/constants'
+import { getPath, ProjectValidations } from '../../../shared/constants'
 import { useDebounce } from '../../../shared/hooks'
+import { Feedback, FeedBackVariant } from '../../../shared/molecules/Feedback.tsx'
 import { ImageCropAspectRatio } from '../../../shared/molecules/ImageCropperModal'
 import { MediaControlWithReorder } from '../../../shared/molecules/MediaControlWithReorder'
 import { Country, useProjectByNameForNameCheckLazyQuery } from '../../../types'
@@ -29,6 +31,20 @@ import { ProjectLinks } from './ProjectLinks.tsx'
 import { ProjectTagsCreateEdit } from './ProjectTagsCreateEdit.tsx'
 
 const MIN_LENGTH_TO_QUERY_PROJECT = 3
+
+const QUERY_LABIF_COUNTRY_ELIGIBILITY = gql`
+  query LabifCountryEligibility($countryCode: String) {
+    impactFundLabifCountryEligibility(countryCode: $countryCode) {
+      isEligible
+    }
+  }
+`
+
+type LabifCountryEligibilityQuery = {
+  impactFundLabifCountryEligibility: {
+    isEligible: boolean
+  }
+}
 
 export const MAX_PROJECT_HEADERS = 7
 
@@ -73,6 +89,10 @@ export const ProjectForm = ({ form, isEdit }: ProjectFormProps) => {
 
   const projectName = watch('name')
   const debouncedProjectName = useDebounce(projectName, 500)
+  const [getLabifEligibility, { data: labifEligibility }] = useLazyQuery<LabifCountryEligibilityQuery>(
+    QUERY_LABIF_COUNTRY_ELIGIBILITY,
+    { fetchPolicy: 'network-only' },
+  )
 
   useEffect(() => {
     if (debouncedProjectName) {
@@ -354,8 +374,29 @@ export const ProjectForm = ({ form, isEdit }: ProjectFormProps) => {
           getOptionLabel={(option: Country) => option.name}
           getOptionValue={(option: Country) => option.code}
           onFocus={() => clearErrors('location')}
+          onChange={(country) => {
+            const countryCode = (country as Country | null)?.code || null
+            getLabifEligibility({ variables: { countryCode } })
+          }}
         />
       </FieldContainer>
+
+      {labifEligibility?.impactFundLabifCountryEligibility.isEligible ? (
+        <Feedback variant={FeedBackVariant.INFO} noIcon>
+          <Body size="sm" color="inherit">
+            {t('This project may be eligible to receive funding from the Latin America Bitcoin Impact Fund. ')}
+            <ChakraLink
+              href={getPath('impactFunds', 'latam-impact-fund')}
+              target="_blank"
+              rel="noopener noreferrer"
+              textDecoration="underline"
+              _hover={{ textDecoration: 'underline' }}
+            >
+              {t('Learn more about how to apply.')}
+            </ChakraLink>
+          </Body>
+        </Feedback>
+      ) : null}
 
       <ProjectLinks form={form} />
 


### PR DESCRIPTION
Introduces a new feature that displays a Latin America Bitcoin Impact Fund (LABIF) eligibility callout on project forms.

- Queries LABIF country eligibility based on the selected project country.
- Shows an informational message and a link to learn more about the fund if the project's country is deemed eligible.

This helps users identify potential funding opportunities from the LABIF.